### PR TITLE
blog-cardショートコードのエラーハンドリングを修正

### DIFF
--- a/layouts/shortcodes/blog-card.html
+++ b/layouts/shortcodes/blog-card.html
@@ -20,11 +20,11 @@
             {{- end -}}
         {{- end -}}
 
-        {{- $thumbnail := resources.GetRemote $image -}}
-        {{- if $thumbnail.Err -}}
-            {{- $thumbnail = resources.Get $.Site.Params.dafaultNoimage -}}
-            {{- $thumbnail = $thumbnail.Fit (printf "200x200 center q%d webp" $.Site.Params.imageQuality) -}}
+        {{- $thumbnail := (resources.Get 0) -}}
+        {{- with resources.GetRemote $image -}}
+            {{- $thumbnail = .Fit (printf "200x200 center q%d webp" $.Site.Params.imageQuality) -}}
         {{- else -}}
+            {{- $thumbnail = resources.Get $.Site.Params.dafaultNoimage -}}
             {{- $thumbnail = $thumbnail.Fit (printf "200x200 center q%d webp" $.Site.Params.imageQuality) -}}
         {{- end -}}
 


### PR DESCRIPTION
こちらのコードで、事象解消できました。
ご確認お願いいたします。 

なお↓のコードでもいけました。
```
        {{- $thumbnail := resources.GetRemote $image -}}
        {{- with $thumbnail -}}
        {{- else -}}
            {{- $thumbnail = resources.Get $.Site.Params.dafaultNoimage -}}
        {{- end -}}
        {{- $thumbnail = $thumbnail.Fit (printf "200x200 center q%d webp" $.Site.Params.imageQuality) -}}
```
上記のコードの方がシンプルですが、
 resources.GetRemote $image を2重に実行する？動きになるのか、判断がつかなったため、
PRで送信したコードは既存のコードに近い記述にしました。

---
＃はじめ with .Err で試行錯誤していたのですが、結局うまくいきませんでした。