### PR TITLE
Twitterアイコン・リンクをXに対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         sed -ie "s|name: my_organization|name: okdyy75|" config.yml
         sed -ie "s|url: https://example.com/publisher|url: https://github.com/okdyy75|" config.yml
         sed -ie "s|description: organization_description|description: Hugo用ブログテーマ「Salt」を作りました|" config.yml
-        sed -ie "s|https://example.com/sameAs|https://twitter.com/okdyy75|" config.yml
+        sed -ie "s|https://example.com/sameAs|https://x.com/okdyy75|" config.yml
         sed -ie "s|twitterTimeline: twitter|twitterTimeline:|" config.yml
         echo '<script>let isLoaded = false; window.addEventListener( "scroll", function () { if (isLoaded) { return; } if (document.documentElement.scrollTop != 0 || document.body.scrollTop != 0) { (function () { const GoogleAdSenseId = "ca-pub-9459277760652211"; let e = document.createElement("script"); e.type = "text/javascript"; e.crossorigin = "anonymous"; e.async = true; e.src = "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=" + GoogleAdSenseId; document.body.appendChild(e); e.onload = function(){ document.querySelector("header .google-auto-placed").remove(); } })(); (function () { const GoogleAnalyticsId = "G-LR5GBHW5M5"; let e = document.createElement("script"); e.type = "text/javascript"; e.async = true; e.src = "https://www.googletagmanager.com/gtag/js?id=" + GoogleAnalyticsId; document.body.appendChild(e); window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); } gtag("js", new Date()); gtag("config", GoogleAnalyticsId); })(); isLoaded = true; } }, true );</script>' >> ./layouts/partials/body-add.html
         npm run build

--- a/assets/scss/layouts/partials/share-links.scss
+++ b/assets/scss/layouts/partials/share-links.scss
@@ -26,8 +26,8 @@
         &__itemLink {
             &--twitter {
                 @extend %__itemLink;
-                background: #1da1f1;
-                box-shadow: 0 3px 0 #0092ca;
+                background: #000000;
+                box-shadow: 0 3px 0 #333333;
             }
             &--facebook {
                 @extend %__itemLink;

--- a/assets/scss/layouts/partials/sns-links.scss
+++ b/assets/scss/layouts/partials/sns-links.scss
@@ -18,7 +18,7 @@
         &__link {
             &--twitter {
                 @extend %__link;
-                background:#1da1f1;
+                background:#000000;
             }
             &--instagram {
                 @extend %__link;

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -1,7 +1,7 @@
 <ul class="partials__shareLinks">
     <li class="partials__shareLinks__item">
         <a href="http://twitter.com/intent/tweet?url={{ .Permalink }}&text={{ .Title }}" target="_blank" title="Tweet" class="partials__shareLinks__itemLink--twitter">
-            <i class="fab fa-twitter"></i>Twitter
+            <i class="fab fa-x-twitter"></i>Twitter
         </a>
     </li>
     <li class="partials__shareLinks__item">

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -1,6 +1,6 @@
 <ul class="partials__shareLinks">
     <li class="partials__shareLinks__item">
-        <a href="http://twitter.com/intent/tweet?url={{ .Permalink }}&text={{ .Title }}" target="_blank" title="Tweet" class="partials__shareLinks__itemLink--twitter">
+        <a href="http://x.com/intent/tweet?url={{ .Permalink }}&text={{ .Title }}" target="_blank" title="Tweet" class="partials__shareLinks__itemLink--twitter">
             <i class="fab fa-x-twitter"></i>Twitter
         </a>
     </li>

--- a/layouts/partials/sns-links.html
+++ b/layouts/partials/sns-links.html
@@ -2,7 +2,7 @@
 <div class="partials__snsLinks">
     {{ if $link.twitter }}
         <a href="https://twitter.com/{{ $link.twitter }}" target="_blank" class="partials__snsLinks__link--twitter">
-            <i class="fa-lg fab fa-twitter"></i>
+            <i class="fa-lg fab fa-x-twitter"></i>
         </a>
     {{ end }}
     {{ if $link.instagram }}

--- a/layouts/partials/sns-links.html
+++ b/layouts/partials/sns-links.html
@@ -1,7 +1,7 @@
 {{ $link := .link }}
 <div class="partials__snsLinks">
     {{ if $link.twitter }}
-        <a href="https://twitter.com/{{ $link.twitter }}" target="_blank" class="partials__snsLinks__link--twitter">
+        <a href="https://x.com/{{ $link.twitter }}" target="_blank" class="partials__snsLinks__link--twitter">
             <i class="fa-lg fab fa-x-twitter"></i>
         </a>
     {{ end }}


### PR DESCRIPTION
## 変更内容
- TwitterアイコンをXに差し替え
- Twitterリンクのドメインをtwitter.com→x.comに更新

### スクリーンショット

twitterリンク

<img width="555" alt="スクリーンショット 2024-05-27 19 39 18" src="https://github.com/okdyy75/hugo-theme-salt/assets/31526134/6f5748bf-62f4-45c8-8e0e-505c53608c89">

<hr>

twitterアイコン

<img width="374" alt="スクリーンショット 2024-05-27 19 39 33" src="https://github.com/okdyy75/hugo-theme-salt/assets/31526134/d94dabd5-af55-4718-ab27-6becdfa218b6">

