### PR TITLE
thumbnailに設定している画像が存在しない場合ビルドエラーになるのを修正

### DIFF
--- a/exampleContent/article/hugo/search/index.md
+++ b/exampleContent/article/hugo/search/index.md
@@ -75,6 +75,16 @@ layouts/search/list.json
 ```go-template
 {{- $.Scratch.Add "index" slice -}}
 {{- range where .Site.RegularPages ".Section" "==" "article" -}}
+    {{- $data := dict
+        "title" .Title
+        "description" .Description
+        "summary" .Summary
+        "date" (.Date.Format "2006-01-02")
+        "lastmod" (.Lastmod.Format "2006-01-02")
+        "tags" .Params.tags
+        "categories" .Params.categories
+        "href" .Permalink
+    -}}
     {{- $thumbnail := or
         (.Resources.GetMatch "thumbnail.*")
         (resources.Get .Params.thumbnail)
@@ -82,18 +92,9 @@ layouts/search/list.json
     -}}
     {{- if $thumbnail -}}
         {{- $thumbnail = $thumbnail.Fill (printf "640x360 center q%d webp" .Site.Params.imageQuality) -}}
+        {{- $data = merge $data (dict "thumbnail" $thumbnail.Permalink) -}}
     {{- end -}}
-    {{- $.Scratch.Add "index" (
-        dict "title" .Title
-            "description" .Description
-            "thumbnail" $thumbnail.Permalink
-            "summary" .Summary
-            "date" (.Date.Format "2006-01-02")
-            "lastmod" (.Lastmod.Format "2006-01-02")
-            "tags" .Params.tags
-            "categories" .Params.categories
-            "href" .Permalink
-    ) -}}
+    {{- $.Scratch.Add "index" $data -}}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}
 ```

--- a/layouts/partials/article-card.html
+++ b/layouts/partials/article-card.html
@@ -8,8 +8,8 @@
         }}
         {{ if $thumbnail }}
             {{ $thumbnail = $thumbnail.Fill (printf "640x360 center q%d webp" .Site.Params.imageQuality) }}
+            <img src='{{ $thumbnail.Permalink  }}' alt="{{ .Title }}" loading="lazy" class="partials__articleCard__thumbnail">
         {{ end }}
-        <img src='{{ $thumbnail.Permalink  }}' alt="{{ .Title }}" loading="lazy" class="partials__articleCard__thumbnail">
         <h4 class="partials__articleCard__title">
             {{ .Title }}
         </h4>

--- a/layouts/partials/related-article.html
+++ b/layouts/partials/related-article.html
@@ -8,8 +8,8 @@
         }}
         {{ if $thumbnail }}
             {{ $thumbnail = $thumbnail.Fill (printf "576x324 center q%d webp" .Site.Params.imageQuality) }}
+            <img src='{{ $thumbnail.Permalink  }}' alt="{{ .Title }}" loading="lazy" class="partials__relatedArticle__thumbnail">
         {{ end }}
-        <img src='{{ $thumbnail.Permalink  }}' alt="{{ .Title }}" loading="lazy" class="partials__relatedArticle__thumbnail">
         <div class="partials__relatedArticle__content">
             <h4 class="partials__relatedArticle__title">
                 {{ .Title }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -105,8 +105,8 @@
                                 }}
                                 {{ if $thumbnail }}
                                     {{ $thumbnail = $thumbnail.Fill (printf "192x108 center q%d webp" .Site.Params.imageQuality) }}
+                                    <img src='{{ $thumbnail.Permalink }}' alt="{{ .Title }}" loading="lazy" class="partials__sidebar__article__itemThumbnail">
                                 {{ end }}
-                                <img src='{{ $thumbnail.Permalink }}' alt="{{ .Title }}" loading="lazy" class="partials__sidebar__article__itemThumbnail">
                                 <div class="partials__sidebar__article__itemDetail">
                                     <div class="partials__sidebar__article__itemTitle--line3">
                                         {{ .Title }}
@@ -136,8 +136,8 @@
                                     }}
                                     {{ if $thumbnail }}
                                         {{ $thumbnail = $thumbnail.Fill (printf "192x108 center q%d webp" .Site.Params.imageQuality) }}
+                                        <img src='{{ $thumbnail.Permalink }}' alt="{{ .Title }}" loading="lazy" class="partials__sidebar__article__itemThumbnail">
                                     {{ end }}
-                                    <img src='{{ $thumbnail.Permalink }}' alt="{{ .Title }}" loading="lazy" class="partials__sidebar__article__itemThumbnail">
                                     <div class="partials__sidebar__article__itemDetail">
                                         <div class="partials__sidebar__article__itemTitle--line3">
                                             {{ .Title }}
@@ -178,8 +178,8 @@
                                         }}
                                         {{ if $thumbnail }}
                                             {{ $thumbnail = $thumbnail.Fill (printf "192x108 center q%d webp" .Site.Params.imageQuality) }}
+                                            <img src='{{ $thumbnail.Permalink }}' alt="{{ .Title }}" loading="lazy" class="partials__sidebar__article__itemThumbnail">
                                         {{ end }}
-                                        <img src='{{ $thumbnail.Permalink }}' alt="{{ .Title }}" loading="lazy" class="partials__sidebar__article__itemThumbnail">
                                         <div class="partials__sidebar__article__itemDetail">
                                             <div class="partials__sidebar__article__itemTitle--line2">
                                                 {{ .Title }}

--- a/layouts/search/list.json
+++ b/layouts/search/list.json
@@ -1,5 +1,15 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range where .Site.RegularPages ".Section" "==" "article" -}}
+    {{- $data := dict
+        "title" .Title
+        "description" .Description
+        "summary" .Summary
+        "date" (.Date.Format "2006-01-02")
+        "lastmod" (.Lastmod.Format "2006-01-02")
+        "tags" .Params.tags
+        "categories" .Params.categories
+        "href" .Permalink
+    -}}
     {{- $thumbnail := or
         (.Resources.GetMatch "thumbnail.*")
         (resources.Get .Params.thumbnail)
@@ -7,17 +17,8 @@
     -}}
     {{- if $thumbnail -}}
         {{- $thumbnail = $thumbnail.Fill (printf "640x360 center q%d webp" .Site.Params.imageQuality) -}}
+        {{- $data = merge $data (dict "thumbnail" $thumbnail.Permalink) -}}
     {{- end -}}
-    {{- $.Scratch.Add "index" (
-        dict "title" .Title
-            "description" .Description
-            "thumbnail" $thumbnail.Permalink
-            "summary" .Summary
-            "date" (.Date.Format "2006-01-02")
-            "lastmod" (.Lastmod.Format "2006-01-02")
-            "tags" .Params.tags
-            "categories" .Params.categories
-            "href" .Permalink
-    ) -}}
+    {{- $.Scratch.Add "index" $data -}}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}


### PR DESCRIPTION
### 修正内容
- フロントマターのthumbnailで設定している画像ない場合ビルドエラーになるのを修正
  - `thimbnail: /article/hoge/fug.jpg` の画像が存在しない場合にエラーになる