### PR TITLE
Fix/39 sidebar category link

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -205,7 +205,7 @@
                 <ul class="partials__sidebar__category__items">
                     {{ range .Site.Taxonomies.categories.ByCount }}
                         <li class="partials__sidebar__category__item">
-                            <a href="{{ "categories" | relURL }}/{{ .Term }}" class="partials__sidebar__category__itemLink">
+                            <a href="{{ .Page.Permalink }}" class="partials__sidebar__category__itemLink">
                                 <div>
                                     <i class="fas fa-arrow-circle-right partials__sidebar__category__itemIcon"></i>
                                     {{ .Term }}


### PR DESCRIPTION
## 変更内容
- [サイドバーのカテゴリーリンクが404になるのを修正](https://github.com/okdyy75/hugo-theme-salt/commit/1b2bc006a374363f16ea6bfee192038cf1210e89)

## Issues
#39 

### 参考リンク
https://juggernautjp.info/templates/taxonomy-templates/