### PR TITLE
fix: Issue #100 ダークモード時の本文背景

### DIFF
--- a/assets/scss/layouts/_default/single.scss
+++ b/assets/scss/layouts/_default/single.scss
@@ -94,6 +94,7 @@
             }
             &.markdown-body {
                 color: $base-font-color;
+                background: $base-background;
                 pre, table {
                     background: #f6f8fa;
                     color: #000;

--- a/assets/scss/layouts/_default/single.scss
+++ b/assets/scss/layouts/_default/single.scss
@@ -95,9 +95,14 @@
             &.markdown-body {
                 color: $base-font-color;
                 background: $base-background;
-                pre, table {
-                    background: #f6f8fa;
-                    color: #000;
+                color-scheme: light;
+                --bgColor-default: #{$base-background};
+                --bgColor-muted: #{$light-background};
+                --borderColor-default: #{$light-border};
+                --borderColor-muted: #{$light-border};
+                pre {
+                    background: $light-background;
+                    color: $base-font-color;
                 }
             }
         }


### PR DESCRIPTION
## 🎯 概要
OSのダークモード時でも本文の背景が黒くならないように調整しました。

## 🔗 関連Issue
fix #100

## 📝 変更内容
- `assets/scss/layouts/_default/single.scss` の `.markdown-body` に背景色を指定

### 動作確認
- ユーザー確認済み（OSのダークモード切替で本文が読めること）

## 💡 その他（参考資料、関連リンク、補足）

