### PR TITLE
HugoのData参照を互換性優先に戻す

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -152,7 +152,7 @@
         {{ end }}
 
         {{ $ranking := slice }}
-        {{ range $item := sort hugo.Data.ranking.items "pv" "desc" }}
+        {{ range $item := sort .Site.Data.ranking.items "pv" "desc" }}
             {{ with $page := $.Site.GetPage (path.Clean $item.pagePath) }}
                 {{ if eq .Section "article" }}
                     {{ $ranking = $ranking | append (dict "page" $page "pv" $item.pv) }}


### PR DESCRIPTION
## 🎯 概要

Hugo 0.147.5 で `hugo.Data` が利用できず、`npm run build` が失敗するため、ランキング表示のデータ参照を互換性優先で `.Site.Data` に戻しました。

## 🔗 関連Issue
fix #

## 📝 変更内容

- サイドバーのランキング表示で `hugo.Data` 参照を `.Site.Data` に戻す
- 古い Hugo バージョンでも `npm run build` が通る状態に修正

### 動作確認

- `npm run build -- --config config.org.yml`
- Hugo 0.147.5 でビルドが成功することを確認
- Hugo 0.161.1 では `.Site.Data` の deprecated warn は出るが、古い Hugo 互換を優先するため許容

## 💡 その他（参考資料、関連リンク、補足）

- PR #105 の `hugo.Data` 変更に対する互換性修正です